### PR TITLE
feat(Pokemon): Implement remote data source for Pokemon API

### DIFF
--- a/lib/config/constants/environment.dart
+++ b/lib/config/constants/environment.dart
@@ -1,0 +1,9 @@
+import 'dart:io';
+
+class Environment {
+  static String apiUrl =
+      Platform.isAndroid
+          //TODO:
+          ? 'http://192.168.16.23:3000'
+          : 'http://localhost:3000';
+}

--- a/lib/core/error/failures.dart
+++ b/lib/core/error/failures.dart
@@ -1,7 +1,5 @@
 import 'package:equatable/equatable.dart';
 
-//TODO:
-
 abstract class Failure extends Equatable {
   final String message;
 
@@ -12,23 +10,21 @@ abstract class Failure extends Equatable {
 }
 
 class ServerFailure extends Failure {
-  const ServerFailure({super.message = 'Error en el servidor.'});
+  const ServerFailure({super.message = 'Server error.'});
 }
 
 class NetworkFailure extends Failure {
-  const NetworkFailure({super.message = 'Error de conexión de red.'});
+  const NetworkFailure({super.message = 'Network connection error.'});
 }
 
 class CacheFailure extends Failure {
-  const CacheFailure({super.message = 'Se produjo un error de caché.'});
+  const CacheFailure({super.message = 'A cache error occurred.'});
 }
 
 class PokemonFailure extends Failure {
-  const PokemonFailure({
-    super.message = 'Error al obtener los datos de Pokémon.',
-  });
+  const PokemonFailure({super.message = 'Error retrieving Pokemon data.'});
 }
 
 class BattleFailure extends Failure {
-  const BattleFailure({super.message = 'Error durante el proceso de batalla.'});
+  const BattleFailure({super.message = 'Error during battle process.'});
 }

--- a/lib/features/battle/data/datasources/local_battle_datasource_impl.dart
+++ b/lib/features/battle/data/datasources/local_battle_datasource_impl.dart
@@ -7,7 +7,7 @@ import 'package:pokemon_app/features/battle/data/models/battle_model.dart';
 import 'package:pokemon_app/features/battle/domain/datasources/battle_datasource.dart';
 import 'package:pokemon_app/features/battle/domain/entities/entities.dart';
 
-class LocalBattleDatasourceImpl extends BattleDatasource {
+class LocalBattleDatasourceImpl implements BattleDatasource {
   @override
   Future<Either<Failure, BattleEntity>> startBattle(
     String selectedPokemonId,

--- a/lib/features/battle/presentation/widgets/start_battle_button.dart
+++ b/lib/features/battle/presentation/widgets/start_battle_button.dart
@@ -21,7 +21,6 @@ class StartBattleButton extends StatelessWidget {
           style: ElevatedButton.styleFrom(
             backgroundColor: Colors.green,
             foregroundColor: Colors.white,
-            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
           ),
 
           child: const Text('Start Battle', style: TextStyle(fontSize: 16)),

--- a/lib/features/pokemon/data/datasources/local_pokemon_datasource_impl.dart
+++ b/lib/features/pokemon/data/datasources/local_pokemon_datasource_impl.dart
@@ -6,7 +6,7 @@ import 'package:pokemon_app/core/error/errors.dart';
 import 'package:pokemon_app/features/pokemon/domain/entities/entities.dart';
 import 'package:pokemon_app/features/pokemon/domain/datasources/pokemon_datasource.dart';
 
-class LocalPokemonDatasourceImpl extends PokemonDatasource {
+class LocalPokemonDatasourceImpl implements PokemonDatasource {
   @override
   Future<Either<Failure, List<PokemonEntity>>> getPokemonList() async {
     await Future.delayed(const Duration(seconds: 2));

--- a/lib/features/pokemon/data/datasources/remote_pokemon_datasource_impl.dart
+++ b/lib/features/pokemon/data/datasources/remote_pokemon_datasource_impl.dart
@@ -1,0 +1,33 @@
+import 'package:dio/dio.dart';
+import 'package:pokemon_app/core/error/either.dart';
+import 'package:pokemon_app/config/constants/environment.dart';
+import 'package:pokemon_app/core/error/failures.dart';
+import 'package:pokemon_app/features/pokemon/data/mappers/pokemon_mappers.dart';
+import 'package:pokemon_app/features/pokemon/domain/datasources/pokemon_datasource.dart';
+import 'package:pokemon_app/features/pokemon/domain/entities/pokemon_entity.dart';
+
+class RemotePokemonDatasourceImpl implements PokemonDatasource {
+  final Dio dio;
+
+  RemotePokemonDatasourceImpl({required this.dio});
+  @override
+  Future<Either<Failure, List<PokemonEntity>>> getPokemonList() async {
+    try {
+      final response = await dio.get('${Environment.apiUrl}/pokemon');
+      if (response.statusCode == 200) {
+        final pokemonList = PokemonMappers.fromResponseToEntities(
+          response.data,
+        );
+        return Right(pokemonList);
+      } else {
+        return Left(
+          ServerFailure(
+            message: 'Error en el servidor: código ${response.statusCode}',
+          ),
+        );
+      }
+    } catch (e) {
+      return Left(PokemonFailure(message: e.toString()));
+    }
+  }
+}

--- a/lib/features/pokemon/data/mappers/pokemon_mappers.dart
+++ b/lib/features/pokemon/data/mappers/pokemon_mappers.dart
@@ -1,0 +1,18 @@
+import 'package:pokemon_app/features/pokemon/domain/entities/entities.dart';
+
+class PokemonMappers {
+  static List<PokemonEntity> fromResponseToEntities(dynamic responseData) {
+    if (responseData == null || responseData is! Map<String, dynamic>) {
+      throw FormatException('Formato de respuesta inválido');
+    }
+
+    final pokemonList = responseData['pokemon'];
+    if (pokemonList == null || pokemonList is! List) {
+      throw FormatException('Lista de pokemon no encontrada o inválida');
+    }
+
+    return pokemonList
+        .map<PokemonEntity>((json) => PokemonEntity.fromJson(json))
+        .toList();
+  }
+}

--- a/lib/features/pokemon/data/repositories/pokemon_repository_impl.dart
+++ b/lib/features/pokemon/data/repositories/pokemon_repository_impl.dart
@@ -4,7 +4,7 @@ import 'package:pokemon_app/features/pokemon/domain/datasources/pokemon_datasour
 import 'package:pokemon_app/features/pokemon/domain/entities/pokemon_entity.dart';
 import 'package:pokemon_app/features/pokemon/domain/repositories/pokemon_repository.dart';
 
-class PokemonRepositoryImpl extends PokemonRepository {
+class PokemonRepositoryImpl implements PokemonRepository {
   final PokemonDatasource datasource;
 
   PokemonRepositoryImpl(this.datasource);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,36 +1,40 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:pokemon_app/features/pokemon/data/datasources/remote_pokemon_datasource_impl.dart';
 import 'package:provider/provider.dart';
 import 'package:pokemon_app/config/router/app_router.dart';
 import 'package:pokemon_app/features/battle/data/datasources/local_battle_datasource_impl.dart';
 import 'package:pokemon_app/features/battle/data/repositories/battle_repository_impl.dart';
 import 'package:pokemon_app/features/battle/presentation/providers/battle_provider.dart';
-import 'package:pokemon_app/features/pokemon/data/datasources/local_pokemon_datasource_impl.dart';
 import 'package:pokemon_app/features/pokemon/data/repositories/pokemon_repository_impl.dart';
 import 'package:pokemon_app/features/pokemon/presentation/providers/pokemon_provider.dart';
 
-void main() => runApp(
-  MultiProvider(
-    providers: [
-      ChangeNotifierProvider(
-        create:
-            (_) => PokemonProvider(
-              pokemonRepository: PokemonRepositoryImpl(
-                LocalPokemonDatasourceImpl(),
+void main() {
+  final dio = Dio();
+  runApp(
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create:
+              (_) => PokemonProvider(
+                pokemonRepository: PokemonRepositoryImpl(
+                  RemotePokemonDatasourceImpl(dio: dio),
+                ),
+              )..fetchPokemons(),
+        ),
+        ChangeNotifierProvider(
+          create:
+              (_) => BattleProvider(
+                battleRepository: BattleRepositoryImpl(
+                  LocalBattleDatasourceImpl(),
+                ),
               ),
-            )..fetchPokemons(),
-      ),
-      ChangeNotifierProvider(
-        create:
-            (_) => BattleProvider(
-              battleRepository: BattleRepositoryImpl(
-                LocalBattleDatasourceImpl(),
-              ),
-            ),
-      ),
-    ],
-    child: MyApp(),
-  ),
-);
+        ),
+      ],
+      child: MyApp(),
+    ),
+  );
+}
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.0+1"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   equatable:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   go_router: ^14.8.1
   provider: ^6.1.4
   cached_network_image: ^3.4.1
+  dio: ^5.8.0+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Create remote_pokemon_datasource_impl to fetch Pokemon data from API
- Add pokemon_mappers for handling API response
- Update failures with English error messages
- Modify environment configs and pubspec for Dio integration
- Update Pokemon repository implementation

Related issue: #3